### PR TITLE
feat: enable configurable HTTP clients in config providers

### DIFF
--- a/conf.go
+++ b/conf.go
@@ -32,14 +32,12 @@ func defaultProviderWithOpts(optList ...Option) Provider {
 	for _, opt := range optList {
 		opt(o)
 	}
+	httpProviderOpts := make([]HttpProviderOption, 0, 1)
+	if o.httpClient != nil {
+		httpProviderOpts = append(httpProviderOpts, WithHTTPClient(o.httpClient))
+	}
 	return NewProviderGroup(
-		NewHttpProvider(JsonCodec{},
-			func(p *HttpProvider) {
-				if o.httpClient != nil {
-					WithHTTPClient(o.httpClient)(p)
-				}
-			},
-		),
+		NewHttpProvider(JsonCodec{}, httpProviderOpts...),
 		NewLocalProvider(JsonCodec{}),
 	)
 }

--- a/conf.go
+++ b/conf.go
@@ -1,8 +1,45 @@
 package confstore
 
-func Default() Provider {
+import "net/http"
+
+type options struct {
+	httpClient *http.Client
+}
+
+// Option is a functional option for configuring default providers in Load/Save.
+type Option func(*options)
+
+// WithHTTPClientOption sets a custom http.Client for remote HTTP access.
+func WithHTTPClientOption(client *http.Client) Option {
+	return func(o *options) {
+		o.httpClient = client
+	}
+}
+
+// defaultProvider returns the default ProviderGroup according to Option
+func defaultProvider() Provider {
 	return NewProviderGroup(
 		NewHttpProvider(JsonCodec{}),
+		NewLocalProvider(JsonCodec{}),
+	)
+}
+
+func defaultProviderWithOpts(optList ...Option) Provider {
+	if len(optList) == 0 {
+		return defaultProvider()
+	}
+	o := &options{}
+	for _, opt := range optList {
+		opt(o)
+	}
+	return NewProviderGroup(
+		NewHttpProvider(JsonCodec{},
+			func(p *HttpProvider) {
+				if o.httpClient != nil {
+					WithHTTPClient(o.httpClient)(p)
+				}
+			},
+		),
 		NewLocalProvider(JsonCodec{}),
 	)
 }
@@ -14,15 +51,31 @@ func New(codec Codec) Provider {
 	)
 }
 
-func Load[T any](path string) (*T, error) {
+/*
+Load loads config data from the given path using the default provider group.
+Optional functional options can be passed to customize remote access, such as setting the HTTP client.
+
+Example:
+
+	cfg, err := Load[MyType]("http://...", WithHTTPClientOption(myClient))
+*/
+func Load[T any](path string, opts ...Option) (*T, error) {
 	config := new(T)
-	err := Default().Load(path, config)
+	err := defaultProviderWithOpts(opts...).Load(path, config)
 	if err != nil {
 		return nil, err
 	}
 	return config, nil
 }
 
-func Save[T any](path string, conf *T) error {
-	return Default().Save(path, conf)
+/*
+Save saves config data to the given path using the default provider group.
+Optional functional options can be passed to customize remote access, such as setting the HTTP client.
+
+Example:
+
+	err := Save("http://...", conf, WithHTTPClientOption(myClient))
+*/
+func Save[T any](path string, conf *T, opts ...Option) error {
+	return defaultProviderWithOpts(opts...).Save(path, conf)
 }


### PR DESCRIPTION
- Add support for passing a custom http.Client to HTTP-based config loaders and savers via functional options
- Refactor provider initialization to support provider-specific options, such as custom HTTP clients
- Implement functional options for both global Load/Save and HttpProvider construction
- Ensure Load and Save can now be configured with options, increasing flexibility for remote config sources

ref: https://github.com/TBXark/mcp-proxy/issues/25